### PR TITLE
Update Prometheus CHT scrape config to trim instance labels

### DIFF
--- a/prometheus/config/prometheus.yml
+++ b/prometheus/config/prometheus.yml
@@ -22,6 +22,8 @@ scrape_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - source_labels: [__param_target]
+        regex: "(?:https?:\\/\\/|)(?:www\\.|)(.*?)[:/].*"
         target_label: instance
+        replacement: "$1"
       - target_label: __address__
         replacement: json-exporter:7979


### PR DESCRIPTION
Massages the instance label values so they are just the domain name.  Should remove any leading `https//`, `www.`, etc and any trailing port numbers, paths, or query params.

Regex explanation: `(?:https?:\\/\\/|)(?:www\\.|)(.*?)[:/].*`
- `(?:https?:\\/\\/|)` - non-capturing group matching `http`, `https`, or nothing
- `(?:www\\.|)` - non-capturing group matching `www.` or nothing
- `(.*?)` - non-greedy capture group that should grab the desired domain name
- `[:/].*` - range matching a `:` or a `/` followed by anything else