### PR TITLE
feat: Update config so CHT urls do not need monitoring path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,12 @@ mkdir grafana/data && mkdir prometheus/data
 
 #### CHT Instance(s)
 
-Edit the [`cht-instances.yml` file](./cht-instances.yml) to point to your desired CHT instance(s). When using the provided CHT Admin Overview dashboard, you should set the `connected_user_interval=30` parameter on your CHT connection URL (so that the `cht_connected_users_count` metric is populated with user data from the last 30 days).
+Edit the [`cht-instances.yml` file](./cht-instances.yml) to point to your desired CHT instance(s).
 
 ```yml
-  - https://gamma.dev.medicmobile.org/api/v2/monitoring?connected_user_interval=30
+- targets:
+    - https://gamma.dev.medicmobile.org
 ```
-
-To preserve data consistency this parameter value should NOT be adjusted after it is initially set.
 
 #### Email Alerts
 

--- a/cht-instances.example.yml
+++ b/cht-instances.example.yml
@@ -1,7 +1,4 @@
 - targets:
-  # Update this URL to point to your CHT instance's /monitoring endpoint.
-  # Add additional URLs to monitor multiple instances.
-  # (Note that the connected_user_interval parameter affects the time interval that determines the
-  # cht_connected_users_count metric value. To preserve data consistency this value should NOT be adjusted after it is
-  # initially set. When using the provided CHT Admin Overview dashboard, connected_user_interval=30 is required.)
-  - https://gamma.dev.medicmobile.org/api/v2/monitoring?connected_user_interval=30
+    # Update this URL to point to your CHT instance.
+    # Add additional URLs to monitor multiple instances.
+    - https://gamma.dev.medicmobile.org

--- a/prometheus/config/prometheus.yml
+++ b/prometheus/config/prometheus.yml
@@ -20,11 +20,11 @@ scrape_configs:
         - cht-instances.yml
     relabel_configs:
       - source_labels: [__address__]
-        regex: "(.*)"
+        regex: "(.*?)(?:\\/|)$"
         replacement: "${1}/api/v2/monitoring?connected_user_interval=30"
         target_label: __param_target
       - source_labels: [__address__]
-        regex: "(?:https?:\\/\\/|)(?:www\\.|)(.*)"
+        regex: "(?:https?:\\/\\/|)(?:www\\.|)(.*?)(?:\\/|)$"
         target_label: instance
         replacement: "$1"
       - target_label: __address__

--- a/prometheus/config/prometheus.yml
+++ b/prometheus/config/prometheus.yml
@@ -20,9 +20,11 @@ scrape_configs:
         - cht-instances.yml
     relabel_configs:
       - source_labels: [__address__]
+        regex: "(.*)"
+        replacement: "${1}/api/v2/monitoring?connected_user_interval=30"
         target_label: __param_target
-      - source_labels: [__param_target]
-        regex: "(?:https?:\\/\\/|)(?:www\\.|)(.*?)(?:\\/api.*|)"
+      - source_labels: [__address__]
+        regex: "(?:https?:\\/\\/|)(?:www\\.|)(.*)"
         target_label: instance
         replacement: "$1"
       - target_label: __address__

--- a/tests/fake-cht/index.js
+++ b/tests/fake-cht/index.js
@@ -111,7 +111,7 @@ try {
   console.log('Using initial-response data.');
 }
 
-app.get('/', (req, res) => {
+app.get('/api/v2/monitoring', (req, res) => {
   const metrics = {
     version: getVersion(),
     couchdb: getAllCouchDbs(lastResponse.couchdb),


### PR DESCRIPTION
Currently in the `cht-instances.yml` file, you have to configure your URL with the full path to the monitoring endpoint:

```yml
- https://gamma.dev.medicmobile.org/api/v2/monitoring?connected_user_interval=30
```

This is bad for two reasons:

1. Adds additional complexity to the manual configuration (easy to get wrong). And it has to be set for each repeated value.
2. Makes it difficult to re-use the `cht-instances.yml` file configurations for other types of scrapes.  In the future we probably will want to be able to scrape directly from Couch. In that case it would be nice to not have to duplicate this config somewhere else.

The ultimate goal is to just have a single place where administrators can configure the list of CHT instances to monitor.

While working  on scraping Postgres I figured out the proper label config that lets us just set the root URL values in the `cht-instances.yml` file and Prometheus can append everything else automatically.  