### PR TITLE
feat (na) rebrand to Watchdog in admin overview

### DIFF
--- a/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
@@ -103,7 +103,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# CHT Admin Dashboard\n\nSee the [CHT documentation](https://docs.communityhealthtoolkit.org/apps/guides/hosting/monitoring/) for more information about monitoring and alerting!",
+        "content": "# CHT Watchdog\n\nSee the [CHT documentation](https://docs.communityhealthtoolkit.org/apps/guides/hosting/monitoring/) for more information about monitoring and alerting!",
         "mode": "markdown"
       },
       "pluginVersion": "9.4.7",


### PR DESCRIPTION
This PR just changes the JSON to go from `CHT Admin Overview` to `CHT Watchdog`